### PR TITLE
chore: Rails 8.1 で schema.rb を再ダンプ

### DIFF
--- a/awesome-manual/db/schema.rb
+++ b/awesome-manual/db/schema.rb
@@ -10,26 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_12_023810) do
+ActiveRecord::Schema[8.1].define(version: 2025_08_12_023810) do
   create_table "active_storage_attachments", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
   create_table "active_storage_blobs", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
-    t.string "service_name", null: false
     t.bigint "byte_size", null: false
     t.string "checksum"
+    t.string "content_type"
     t.datetime "created_at", null: false
+    t.string "filename", null: false
+    t.string "key", null: false
+    t.text "metadata"
+    t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
@@ -40,9 +40,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_12_023810) do
   end
 
   create_table "manual_tags", force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.integer "manual_id", null: false
     t.integer "tag_id", null: false
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["manual_id", "tag_id"], name: "index_manual_tags_on_manual_id_and_tag_id", unique: true
     t.index ["manual_id"], name: "index_manual_tags_on_manual_id"
@@ -50,26 +50,26 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_12_023810) do
   end
 
   create_table "manuals", force: :cascade do |t|
-    t.string "title", null: false
-    t.text "description"
     t.datetime "created_at", null: false
+    t.text "description"
+    t.string "title", null: false
     t.datetime "updated_at", null: false
   end
 
   create_table "steps", force: :cascade do |t|
-    t.integer "manual_id", null: false
-    t.string "title", null: false
-    t.text "description"
-    t.integer "position", null: false
     t.datetime "created_at", null: false
+    t.text "description"
+    t.integer "manual_id", null: false
+    t.integer "position", null: false
+    t.string "title", null: false
     t.datetime "updated_at", null: false
     t.index ["manual_id", "position"], name: "index_steps_on_manual_id_and_position"
     t.index ["manual_id"], name: "index_steps_on_manual_id"
   end
 
   create_table "tags", force: :cascade do |t|
-    t.string "name", null: false
     t.datetime "created_at", null: false
+    t.string "name", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_tags_on_name", unique: true
   end


### PR DESCRIPTION
## 概要

awesome-manual の `db/schema.rb` を Rails 8.1.2 で再ダンプしました。

## 背景

Gemfile.lock は Rails 8.1.2 に更新済み（#28 ほか）ですが、`schema.rb` が Rails 7.2 時代のダンプのまま残っていました。このままだと、誰かが `db:migrate` を実行するたびに本差分と同じ変更が働き先の PR に混入してしまうため、単独のコミットとして取り込みます。

## 変更内容

- ヘッダーの `ActiveRecord::Schema[7.2]` → `[8.1]`（ダンプに使った Rails バージョンの注記）
- 各テーブルのカラム並びの変更（Rails 8.1 からカラムがアルファベット順でダンプされるようになったため）

**スキーマ本体への変更はありません。** カラム・型・インデックスの追加削除はなく、マイグレーションバージョン（`2025_08_12_023810`）も変わっていないため、既存の開発環境 DB への影響はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)